### PR TITLE
Fixing the error : can't convert nil into Integer (TypeError)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ldap-group-manager (1.2.1)
+    ldap-group-manager (1.2.2)
       awesome_print
       net-ldap (~> 0.16.1)
       ougai (~> 1.7)

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -25,7 +25,7 @@ module AdGear
         GLOBAL_CONFIG[:ldap_host] = ENV['AG_LDAP_HOST']
         GLOBAL_CONFIG[:treebase] = ENV['AG_TREEBASE']
         GLOBAL_CONFIG[:local_state] = ENV['AG_LOCAL_STATE'] || Dir.pwd
-        GLOBAL_CONFIG[:settle_sleep] = Integer(ENV['AG_SETTLE_SLEEP']) || 15
+        GLOBAL_CONFIG[:settle_sleep] = Integer(ENV['AG_SETTLE_SLEEP'] || 15)
 
         GLOBAL_CONFIG.freeze
         # rubocop:enable Style/MutableConstant

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -6,7 +6,7 @@ module AdGear
     module GroupManager
       module Version
         # The global constant holding the version of the gem.
-        GEM_VERSION = '1.2.1'.freeze
+        GEM_VERSION = '1.2.2'.freeze
       end
     end
   end


### PR DESCRIPTION
Fixing the error : /usr/local/bundle/gems/ldap-group-manager-1.2.1/lib/config.rb:28:in `Integer': can't convert nil into Integer (TypeError)

Signed-off-by: David Trefou <d.trefou@samsung.com>