### PR TITLE
Add support for early group memberships

### DIFF
--- a/example_config/organizational/developers.yml
+++ b/example_config/organizational/developers.yml
@@ -20,3 +20,8 @@ pao.developers:
   - user_4
   - user_5
   - user_6
+  - dn: user_7
+    # Be aware that dates _must_ be quoted
+    # otherwise the yaml parser will explode
+    not_before: '2019-10-03T15:44:11-04:00'
+    not_after:  '2019-12-01T00:00:00+00:00'

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -4,8 +4,9 @@ module AdGear
   module Infrastructure
     module GroupManager
       module Config
-        require('yaml')
         require_relative('logging')
+        require('date')
+        require('yaml')
 
         include AdGear::Infrastructure::GroupManager::Logging
 
@@ -17,7 +18,8 @@ module AdGear
             organizational: {},
             functional: {},
             permissions: {}
-          }
+          },
+          today: DateTime.now
         }
 
         GLOBAL_CONFIG[:user_dn] = ENV['AG_USER_DN']
@@ -40,7 +42,56 @@ module AdGear
           target = parts[parts.length - 2]
           Log.debug("target: #{target}")
           data = YAML.safe_load(File.read(file)) || {}
+
           GLOBAL_CONFIG[:data][target.to_sym].merge!(data)
+
+          # Here we resolve time constraints
+          GLOBAL_CONFIG[:data].each do |tl, gs|
+            gs.each do |k, v|
+              next if v.nil?
+              next unless v.key?('member')
+              next if v['member'].nil?
+
+              v['member'].each do |m|
+                next if u.is_a?(String)
+
+                if u.is_a?(Hash)
+                  today = GLOBAL_CONFIG[:today]
+
+                  too_early = false
+                  if u.key?('not_before')
+                    too_early = today < DateTime.parse(u['not_before'])
+                  end
+
+                  debug_message = {
+                    msg: 'Encountered time-bound member',
+                    member: m,
+                    top_level: tl,
+                    group: k,
+                    too_early: too_early
+                  }
+
+                  if too_early
+                    debug_message[:action] = 'ignore'
+                    Log.info(debug_message)
+                  else
+                    debug_message[:action] = 'apply'
+                    Log.debug(debug_message)
+                  end
+
+                  # We always remove the complex object and if it's time
+                  # we insert the string
+                  GLOBAL_CONFIG[:data][tl][k]['member'].delete(m)
+                  GLOBAL_CONFIG[:data][tl][k]['member'] << u['dn'] unless too_early
+                else
+                  Log.fatal(
+                    'Encountered invalid type in member array',
+                    object: k
+                  )
+                end
+              end
+            end
+          end
         end
 
         module_function

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -6,7 +6,7 @@ module AdGear
     module GroupManager
       module Version
         # The global constant holding the version of the gem.
-        GEM_VERSION = '1.2.2'.freeze
+        GEM_VERSION = '1.3.0'.freeze
       end
     end
   end


### PR DESCRIPTION
This PR adds the support for time bound group members. This allows to say from which date onwards should a membership be valid, or whether it should be invalid after a given date.