### PR TITLE
Ignore case when comparing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,4 +24,4 @@ DEPENDENCIES
   ldap-group-manager!
 
 BUNDLED WITH
-   2.1.4
+   2.3.10

--- a/lib/utils.rb
+++ b/lib/utils.rb
@@ -145,9 +145,17 @@ module AdGear::Infrastructure::GroupManager::Utils
     operations
   end
 
-  # A helper method that compares two objects, accounting for LDAP idiosyncracies.
+  # A helper method that compares two objects, accounting for LDAP idiosyncracies and ignoring case.
   # @since 0.1.0
   def compare_attributes(local, remote)
-    (local == [] ? nil : local) != remote
+    if local == nil then
+      local = []
+    end
+
+    if remote == nil then
+      remote = []
+    end
+
+    local.map{ |s| s.downcase } != remote.map{ |s| s.downcase }
   end
 end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -6,7 +6,7 @@ module AdGear
     module GroupManager
       module Version
         # The global constant holding the version of the gem.
-        GEM_VERSION = '1.3.3'.freeze
+        GEM_VERSION = '1.4.0'.freeze
       end
     end
   end


### PR DESCRIPTION
This PR ignores case when comparing local and remote. This fixes classes of false positives where you commit a name with a certain case as a member of a group, but it gets silently reconciled to the user's actual name case in the background. When re-running the diff, a difference in case appears.

Ultimately, LDAP does not care about case when committing changes.